### PR TITLE
refactor/16 consistent command order

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.10.1
+current_version = 0.11.0
 commit = True
 tag = True
 tag_name = v{new_version}

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -12,6 +12,8 @@ replace = version = "{new_version}"
 search = __version__ = "{current_version}"
 replace = __version__ = "{new_version}"
 
-[bumpversion:file:CHANGELOG.md]
-search = ## [Unreleased]
-replace = ## [Unreleased]
+# Note: CHANGELOG.md is intentionally NOT managed by bump2version. A previous
+# [bumpversion:file:CHANGELOG.md] section here silently corrupted release
+# headings on every bump (it rewrote the literal old version string to
+# "## [Unreleased]"). Promote the Unreleased section to a dated release
+# heading manually before bumping.

--- a/.cursor/refactors/5-DONE-command-orders-should-be-more-logical-particularly-for-the-order-commands.md
+++ b/.cursor/refactors/5-DONE-command-orders-should-be-more-logical-particularly-for-the-order-commands.md
@@ -12,3 +12,5 @@ github_issue: 16
 The command order needs to be more logical. For example, in order to change the order of a particular folder, you have to run `cfs instr order features.`. This violates the usual rule that the first argument after `cfs instr` Should be a folder/category name rather than an action. More generally, we need to do an audit of our existing commands and see if they can be laid out in a more logical way. Even as the creator of the program, I often struggle to remember the order of the commands. Given this, it's hard to think that new users would have an easy time of it. 
 
 This ticket will be an iterative effort between the user and the Cursor AI. The Cursor AI should first audit all the existing commands and then suggest ones that could be made more logical. The overall goal is to keep a uniform order to the commands as much as possible. If necessary, we should research best practices for a modern CLI in this respect.
+
+<!-- DONE -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,10 +52,16 @@ src/cfs/
 The skeleton is generated in `cli.py:229` (`initial_content_lines`).
 
 ### CLI Command Pattern
-Commands are organized under `cfs instructions {category}` (aliases: `instr`, `i`):
-- `create`, `edit`, `delete`, `view`, `complete`, `close`
+Commands are organized under `cfs instructions {category}` (aliases: `instr`, `i`) and follow a
+uniform noun-first grammar: `cfs i <category> <verb> [id] [flags]`:
+- `create`, `edit`, `delete`, `view`, `complete`, `uncomplete`, `close`, `unclose`, `check`, `next`, `order`, `move`, `exec`
 
 Category commands are generated dynamically in `create_category_commands()` based on `VALID_CATEGORIES`.
+
+The old verb-first forms (`cfs i order <category>`, `cfs i next <category>`,
+`cfs i move <src> <id> <dest>`, `cfs i view <category>`, `cfs i handoff create-handoff`) are
+deprecated: they are hidden from help, still work, and print a warning pointing at the
+canonical form. They will be removed in a future version.
 
 ## Running Tests
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.0] - 2026-06-11
+
 ### Added
 - Consistent noun-first command grammar (#16): every category-scoped command now follows `cfs i <category> <verb> [id]`. New canonical forms: `cfs i <category> next`, `cfs i <category> order`, `cfs i <category> move <id> <dest-category>`, `cfs i <category> exec <id>`, and `cfs i handoff create`.
 - New built-in `infrastructure-and-deployment` category for infrastructure and deployment-related task documents (peer of `bugs`, `features`, `refactors`, etc.)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 - Verb-first command forms (#16): `cfs i order <category>`, `cfs i next <category>`, `cfs i move <src> <id> <dest>`, `cfs i view <category>`, and `cfs i handoff create-handoff` still work but are hidden from help, print a deprecation warning, and will be removed in a future version. Bare `cfs i view` (all categories) is unchanged.
 
-## [0.10.1] - 2026-06-01
+## [## [Unreleased]] - 2026-06-01
 
 ### Fixed
 - Repaired the test suite (bugs/14): reconciled stale `test_documents.py` tests with intended behavior (structured skeleton on empty content; non-conforming `.md` files are listed) and replaced the removed `CliRunner.isolated_filesystem` with a version-independent helper, so `pytest` passes across Typer/Click versions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Consistent noun-first command grammar (#16): every category-scoped command now follows `cfs i <category> <verb> [id]`. New canonical forms: `cfs i <category> next`, `cfs i <category> order`, `cfs i <category> move <id> <dest-category>`, `cfs i <category> exec <id>`, and `cfs i handoff create`.
 - New built-in `infrastructure-and-deployment` category for infrastructure and deployment-related task documents (peer of `bugs`, `features`, `refactors`, etc.)
 - New built-in `ui` category for UI/UX-related task documents (peer of `bugs`, `features`, `refactors`, etc.)
+
+### Deprecated
+- Verb-first command forms (#16): `cfs i order <category>`, `cfs i next <category>`, `cfs i move <src> <id> <dest>`, `cfs i view <category>`, and `cfs i handoff create-handoff` still work but are hidden from help, print a deprecation warning, and will be removed in a future version. Bare `cfs i view` (all categories) is unchanged.
 
 ## [0.10.1] - 2026-06-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,12 +17,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 - Verb-first command forms (#16): `cfs i order <category>`, `cfs i next <category>`, `cfs i move <src> <id> <dest>`, `cfs i view <category>`, and `cfs i handoff create-handoff` still work but are hidden from help, print a deprecation warning, and will be removed in a future version. Bare `cfs i view` (all categories) is unchanged.
 
-## [## [Unreleased]] - 2026-06-01
+## [0.10.1] - 2026-06-01
 
 ### Fixed
 - Repaired the test suite (bugs/14): reconciled stale `test_documents.py` tests with intended behavior (structured skeleton on empty content; non-conforming `.md` files are listed) and replaced the removed `CliRunner.isolated_filesystem` with a version-independent helper, so `pytest` passes across Typer/Click versions.
 
-## [## [Unreleased]] - 2026-01-09
+## [0.1.0] - 2026-01-09
 
 ### Added
 - Initial release of cursor-instructions-cli

--- a/README.md
+++ b/README.md
@@ -222,13 +222,13 @@ The `next` command automatically finds and works on the first unresolved issue i
 
 ```bash
 # Find and work on the next unresolved bug
-cfs instructions next bugs
+cfs instructions bugs next
 # Or use the short form:
-cfs instr next bugs
+cfs instr bugs next
 
 # Find and work on the next unresolved feature
-cfs instructions next features
-# Or: cfs instr next features
+cfs instructions features next
+# Or: cfs instr features next
 ```
 
 **How it works:**
@@ -239,7 +239,7 @@ cfs instructions next features
 
 **Example:**
 ```bash
-$ cfs instructions next bugs
+$ cfs instructions bugs next
 
 Next issue in bugs: Fix login bug
 Category: bugs, ID: 1
@@ -459,22 +459,26 @@ $ cfs instr planning-notes create --title "Q2 roadmap"
 - `cfs instructions <category> create [--title TITLE] [--edit] [--content TEXT]` - Create new document
 - `cfs instructions <category> edit <id> [--content TEXT]` - Edit existing document
 - `cfs instructions <category> delete <id> [--force]` - Delete document
-- `cfs instructions <category> view` - View documents in category
-- `cfs instructions view [category]` - View all documents or filter by category
+- `cfs instructions <category> view [id]` - View documents in category (or one document by ID)
+- `cfs instructions view` - View all documents across all categories
 - `cfs instructions <category> complete <id> [--force/-y]` - Mark document as done (requires confirmation)
 - `cfs instructions <category> order` - Order documents by naming convention
-- `cfs instructions next <category>` - Find and work on the next unresolved issue
+- `cfs instructions <category> next` - Find and work on the next unresolved issue
+- `cfs instructions <category> move <id> <dest-category>` - Move a document to another category
+- `cfs instructions <category> exec <id>` - Output a document as custom instructions (also: `cfs exec <category> <id>`)
 - `cfs instructions category create <name> [--hidden]` - Create a custom category folder
 - `cfs instructions category hide <name>` - Hide a category from GitHub sync by default
 - `cfs instructions category unhide <name>` - Unhide a category for GitHub sync by default
 - `cfs instructions category list` - List built-in/custom categories and sync visibility
-- `cfs instructions handoff` - Generate instructions for creating a handoff document
+- `cfs instructions handoff create` - Generate instructions for creating a handoff document (or bare `cfs instructions handoff`)
 - `cfs instructions handoff pickup` - Pick up the first incomplete handoff document
+
+**Command grammar:** every category-scoped command follows the same order: `cfs instructions <category> <verb> [id] [flags]`. The old verb-first forms (`cfs i order <category>`, `cfs i next <category>`, `cfs i move <src> <id> <dest>`, `cfs i view <category>`, `cfs i handoff create-handoff`) still work but are deprecated, print a warning, and will be removed in a future version.
 
 **Examples with short alias:**
 - `cfs instr view` - View all documents
 - `cfs instr bugs create --title "Fix bug"` - Create a bug document
-- `cfs instr next features` - Work on next feature
+- `cfs instr features next` - Work on next feature
 
 ### Rules Commands
 
@@ -620,7 +624,7 @@ cfs instructions features complete 1 --force
 
 ```bash
 # Work on the next unresolved bug
-cfs instructions next bugs
+cfs instructions bugs next
 
 # After fixing, mark it as complete (will prompt for confirmation)
 cfs instructions bugs complete 1
@@ -628,7 +632,7 @@ cfs instructions bugs complete 1
 cfs instructions bugs complete 1 -y
 
 # Continue with the next issue
-cfs instructions next bugs
+cfs instructions bugs next
 ```
 
 ### Example Workflow: Agent Handoff

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "cursor-fs-cli"
-version = "0.10.1"
+version = "0.11.0"
 description = "CLI tool for managing Cursor File Structure (CFS) documents"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/src/cfs/__init__.py
+++ b/src/cfs/__init__.py
@@ -3,7 +3,7 @@
 A CLI for managing Cursor instruction documents within a structured file system.
 """
 
-__version__ = "0.10.1"
+__version__ = "0.11.0"
 
 # Export exceptions for easy access
 from cfs.exceptions import (

--- a/src/cfs/cli.py
+++ b/src/cfs/cli.py
@@ -14,19 +14,13 @@ from cfs.cli_helpers import (
     handle_cfs_error,
 )
 from cfs.cli_instructions import (
-    _launch_claude_code,
-    _launch_codex,
-    _launch_cursor_agent,
-    _launch_gemini,
+    exec_document_impl,
     instructions_app,
     view_all,
 )
 from cfs.cli_rules import rules_app
 from cfs.exceptions import (
     CFSNotFoundError,
-    DocumentNotFoundError,
-    InvalidCategoryError,
-    InvalidDocumentIDError,
 )
 
 app = typer.Typer(
@@ -289,6 +283,8 @@ def exec_document(
     This command reads a document and outputs its content as custom instructions that can be
     given to a Cursor agent. Use AI service flags to start a session directly.
 
+    Also available as `cfs i <category> exec <id>`.
+
     Examples:
         cfs exec bugs 1          # Execute document with ID 1 in bugs category
         cfs exec bugs next       # Execute the next document in bugs category
@@ -298,150 +294,7 @@ def exec_document(
         cfs exec bugs 1 --cursor # Start Cursor Agent CLI session with document
         cfs exec bugs 1 --codex  # Start OpenAI Codex CLI session with document
     """
-    from cfs.documents import (
-        find_document_by_id,
-        get_document_title,
-        get_next_document_id,
-        parse_document_id_from_string,
-    )
-
-    # Check for mutual exclusivity of AI service flags
-    ai_flags = [
-        ("--claude", claude),
-        ("--gemini", gemini),
-        ("--cursor", cursor),
-        ("--codex", codex),
-    ]
-    selected_flags = [name for name, value in ai_flags if value]
-    if len(selected_flags) > 1:
-        console.print(
-            f"[red]Error: Only one AI service flag can be used at a time. "
-            f"You specified: {', '.join(selected_flags)}[/red]"
-        )
-        raise typer.Abort()
-
-    try:
-        # Find CFS root
-        cfs_root = core.find_cfs_root()
-    except CFSNotFoundError as e:
-        handle_cfs_error(e)
-        raise typer.Abort()
-
-    # Validate category
-    try:
-        category_path = core.get_category_path(cfs_root, category)
-    except InvalidCategoryError as e:
-        handle_cfs_error(e)
-        raise typer.Abort()
-
-    # Determine which document to execute
-    target_doc_id: Optional[int] = None
-
-    if next_flag or (doc_id and doc_id.lower() == "next"):
-        # Get next document
-        target_doc_id = get_next_document_id(category_path)
-        if target_doc_id is None:
-            console.print(
-                f"[yellow]No documents found in {category} category[/yellow]",
-            )
-            raise typer.Abort()
-    elif doc_id:
-        # Parse provided document ID
-        try:
-            target_doc_id = parse_document_id_from_string(doc_id)
-        except InvalidDocumentIDError as e:
-            handle_cfs_error(e)
-            raise typer.Abort()
-    else:
-        # No doc_id provided and --next not used - prompt user
-        console.print(
-            "[yellow]No document ID provided. Use a number, 'next', or --next flag[/yellow]"
-        )
-        raise typer.Abort()
-
-    # Find document
-    doc_path = find_document_by_id(category_path, target_doc_id)
-    if doc_path is None or not doc_path.exists():
-        try:
-            raise DocumentNotFoundError(target_doc_id, category)
-        except DocumentNotFoundError as e:
-            handle_cfs_error(e)
-            raise typer.Abort()
-
-    # Get document title and content
-    try:
-        title = get_document_title(doc_path)
-        content = doc_path.read_text(encoding="utf-8")
-    except (OSError, IOError) as e:
-        console.print(f"[red]Error reading document: {e}[/red]")
-        raise typer.Abort()
-
-    # Determine which AI service is selected (if any)
-    ai_service = None
-    if claude:
-        ai_service = "Claude Code"
-    elif gemini:
-        ai_service = "Gemini CLI"
-    elif cursor:
-        ai_service = "Cursor Agent CLI"
-    elif codex:
-        ai_service = "OpenAI Codex CLI"
-
-    # Show confirmation (unless --force)
-    if not force:
-        console.print(f"\n[bold]Document:[/bold] {title}")
-        console.print(f"[dim]Category: {category}, ID: {target_doc_id}[/dim]")
-        console.print()
-        if ai_service:
-            confirm_msg = f"Start a {ai_service} session with this document?"
-        else:
-            confirm_msg = "Execute this document? (This will output the instructions text)"
-        if not typer.confirm(confirm_msg, default=False):
-            console.print("[yellow]Execution cancelled[/yellow]")
-            raise typer.Abort()
-
-    if claude:
-        # Launch Claude Code with the document content
-        _launch_claude_code(content, category, target_doc_id)
-    elif gemini:
-        # Launch Gemini CLI with the document content
-        _launch_gemini(content, category, target_doc_id)
-    elif cursor:
-        # Launch Cursor Agent CLI with the document content
-        _launch_cursor_agent(content, category, target_doc_id)
-    elif codex:
-        # Launch OpenAI Codex CLI with the document content
-        _launch_codex(content, category, target_doc_id)
-    else:
-        # Output the document content as custom instructions
-        console.print()
-        console.print("[bold cyan]--- Custom Instructions ---[/bold cyan]")
-        console.print()
-        console.print(content)
-        console.print()
-        console.print("[bold cyan]--- End Custom Instructions ---[/bold cyan]")
-        console.print()
-
-        # Copy to clipboard
-        try:
-            import pyperclip
-
-            pyperclip.copy(content)
-            console.print("[green]✓ Instructions copied to clipboard[/green]")
-        except ImportError:
-            console.print(
-                "[yellow]⚠️  pyperclip not available - cannot copy to clipboard automatically[/yellow]",
-            )
-            console.print(
-                "[dim]Copy the instructions above and provide them to your Cursor agent.[/dim]",
-            )
-        except Exception as e:
-            console.print(
-                f"[yellow]⚠️  Could not copy to clipboard: {e}[/yellow]",
-            )
-            console.print(
-                "[dim]Copy the instructions above and provide them to your Cursor agent.[/dim]",
-            )
+    exec_document_impl(category, doc_id, force, next_flag, claude, gemini, cursor, codex)
 
 
 def main() -> None:

--- a/src/cfs/cli_instructions.py
+++ b/src/cfs/cli_instructions.py
@@ -53,6 +53,14 @@ category_admin_app = typer.Typer(
 instructions_app.add_typer(category_admin_app, name="category")
 
 
+def _warn_deprecated(old_form: str, new_form: str) -> None:
+    """Print a deprecation warning pointing at the canonical command form."""
+    console.print(
+        f"[yellow]⚠️  `{old_form}` is deprecated and will be removed in a future version. "
+        f"Use `{new_form}` instead.[/yellow]"
+    )
+
+
 # =============================================================================
 # Dynamic Category Commands
 # =============================================================================
@@ -1013,6 +1021,111 @@ def create_category_commands(categories: Optional[set[str]] = None) -> None:
                     for issue in issues:
                         console.print(f"  [yellow]- {issue}[/yellow]")
 
+            @category_app.command("next")
+            def next_in_category(
+                force: bool = typer.Option(
+                    False,
+                    "--force",
+                    "-y",
+                    "--yes",
+                    help="Skip confirmation and work on issue immediately",
+                ),
+            ) -> None:
+                """Find and work on the next unresolved issue in this category.
+
+                Shows the title of the first document not marked as DONE and asks
+                if you want to work on it. If yes, displays the full content and
+                copies it to the clipboard.
+                """
+                _next_document_impl(cat, force)
+
+            @category_app.command("order")
+            def order_in_category(
+                force: bool = typer.Option(
+                    False,
+                    "--force",
+                    "-y",
+                    "--yes",
+                    help="Skip confirmation and rename immediately",
+                ),
+            ) -> None:
+                """Order documents in this category by renaming them to follow CFS naming convention."""
+                _order_documents_impl(cat, force)
+
+            @category_app.command("move")
+            def move_in_category(
+                doc_id: str = typer.Argument(..., help="Document ID (numeric or filename)"),
+                dest_category: str = typer.Argument(..., help="Destination category name"),
+                no_renumber: bool = typer.Option(
+                    False,
+                    "--no-renumber",
+                    help="Skip renumbering documents in this category after move",
+                ),
+                force: bool = typer.Option(
+                    False,
+                    "--force",
+                    "-y",
+                    "--yes",
+                    help="Skip confirmation prompt",
+                ),
+            ) -> None:
+                """Move a document from this category to another.
+
+                The document receives a new sequential ID in the destination
+                category. By default, remaining documents in this category are
+                renumbered to fill the gap.
+                """
+                _move_document_impl(cat, doc_id, dest_category, no_renumber, force)
+
+            @category_app.command("exec")
+            def exec_in_category(
+                doc_id: Optional[str] = typer.Argument(
+                    None,
+                    help="Document ID (numeric or 'next')",
+                ),
+                force: bool = typer.Option(
+                    False,
+                    "--force",
+                    "-f",
+                    help="Skip confirmation prompt",
+                ),
+                next_flag: bool = typer.Option(
+                    False,
+                    "--next",
+                    help="Execute the next (first) document in this category",
+                ),
+                claude: bool = typer.Option(
+                    False,
+                    "--claude",
+                    "-c",
+                    help="Start a Claude Code session with this document",
+                ),
+                gemini: bool = typer.Option(
+                    False,
+                    "--gemini",
+                    "-g",
+                    help="Start a Gemini CLI session with this document",
+                ),
+                cursor: bool = typer.Option(
+                    False,
+                    "--cursor",
+                    "-u",
+                    help="Start a Cursor Agent CLI session with this document",
+                ),
+                codex: bool = typer.Option(
+                    False,
+                    "--codex",
+                    "-x",
+                    help="Start an OpenAI Codex CLI session with this document",
+                ),
+            ) -> None:
+                """Execute instructions from a document in this category.
+
+                Outputs the document content as custom instructions text, or
+                starts an AI session with it via the service flags.
+                """
+                exec_document_impl(cat, doc_id, force, next_flag, claude, gemini, cursor, codex)
+
         # Create all commands for this category
         make_category_commands(category)
 
@@ -1194,6 +1307,167 @@ def _launch_codex(content: str, category: str, doc_id: int) -> None:
         console.print("\n[yellow]OpenAI Codex CLI session interrupted[/yellow]")
 
 
+def exec_document_impl(
+    category: str,
+    doc_id: Optional[str],
+    force: bool,
+    next_flag: bool,
+    claude: bool,
+    gemini: bool,
+    cursor: bool,
+    codex: bool,
+) -> None:
+    """Execute instructions from a document by outputting them as custom instructions text.
+
+    Shared implementation behind `cfs exec <category> <id>` and
+    `cfs i <category> exec <id>`.
+    """
+    from cfs.documents import (
+        find_document_by_id,
+        get_document_title,
+        get_next_document_id,
+        parse_document_id_from_string,
+    )
+
+    # Check for mutual exclusivity of AI service flags
+    ai_flags = [
+        ("--claude", claude),
+        ("--gemini", gemini),
+        ("--cursor", cursor),
+        ("--codex", codex),
+    ]
+    selected_flags = [name for name, value in ai_flags if value]
+    if len(selected_flags) > 1:
+        console.print(
+            f"[red]Error: Only one AI service flag can be used at a time. "
+            f"You specified: {', '.join(selected_flags)}[/red]"
+        )
+        raise typer.Abort()
+
+    try:
+        # Find CFS root
+        cfs_root = core.find_cfs_root()
+    except CFSNotFoundError as e:
+        handle_cfs_error(e)
+        raise typer.Abort()
+
+    # Validate category
+    try:
+        category_path = core.get_category_path(cfs_root, category)
+    except InvalidCategoryError as e:
+        handle_cfs_error(e)
+        raise typer.Abort()
+
+    # Determine which document to execute
+    target_doc_id: Optional[int] = None
+
+    if next_flag or (doc_id and doc_id.lower() == "next"):
+        # Get next document
+        target_doc_id = get_next_document_id(category_path)
+        if target_doc_id is None:
+            console.print(
+                f"[yellow]No documents found in {category} category[/yellow]",
+            )
+            raise typer.Abort()
+    elif doc_id:
+        # Parse provided document ID
+        try:
+            target_doc_id = parse_document_id_from_string(doc_id)
+        except InvalidDocumentIDError as e:
+            handle_cfs_error(e)
+            raise typer.Abort()
+    else:
+        # No doc_id provided and --next not used - prompt user
+        console.print(
+            "[yellow]No document ID provided. Use a number, 'next', or --next flag[/yellow]"
+        )
+        raise typer.Abort()
+
+    # Find document
+    doc_path = find_document_by_id(category_path, target_doc_id)
+    if doc_path is None or not doc_path.exists():
+        try:
+            raise DocumentNotFoundError(target_doc_id, category)
+        except DocumentNotFoundError as e:
+            handle_cfs_error(e)
+            raise typer.Abort()
+
+    # Get document title and content
+    try:
+        title = get_document_title(doc_path)
+        content = doc_path.read_text(encoding="utf-8")
+    except (OSError, IOError) as e:
+        console.print(f"[red]Error reading document: {e}[/red]")
+        raise typer.Abort()
+
+    # Determine which AI service is selected (if any)
+    ai_service = None
+    if claude:
+        ai_service = "Claude Code"
+    elif gemini:
+        ai_service = "Gemini CLI"
+    elif cursor:
+        ai_service = "Cursor Agent CLI"
+    elif codex:
+        ai_service = "OpenAI Codex CLI"
+
+    # Show confirmation (unless --force)
+    if not force:
+        console.print(f"\n[bold]Document:[/bold] {title}")
+        console.print(f"[dim]Category: {category}, ID: {target_doc_id}[/dim]")
+        console.print()
+        if ai_service:
+            confirm_msg = f"Start a {ai_service} session with this document?"
+        else:
+            confirm_msg = "Execute this document? (This will output the instructions text)"
+        if not typer.confirm(confirm_msg, default=False):
+            console.print("[yellow]Execution cancelled[/yellow]")
+            raise typer.Abort()
+
+    if claude:
+        # Launch Claude Code with the document content
+        _launch_claude_code(content, category, target_doc_id)
+    elif gemini:
+        # Launch Gemini CLI with the document content
+        _launch_gemini(content, category, target_doc_id)
+    elif cursor:
+        # Launch Cursor Agent CLI with the document content
+        _launch_cursor_agent(content, category, target_doc_id)
+    elif codex:
+        # Launch OpenAI Codex CLI with the document content
+        _launch_codex(content, category, target_doc_id)
+    else:
+        # Output the document content as custom instructions
+        console.print()
+        console.print("[bold cyan]--- Custom Instructions ---[/bold cyan]")
+        console.print()
+        console.print(content)
+        console.print()
+        console.print("[bold cyan]--- End Custom Instructions ---[/bold cyan]")
+        console.print()
+
+        # Copy to clipboard
+        try:
+            import pyperclip
+
+            pyperclip.copy(content)
+            console.print("[green]✓ Instructions copied to clipboard[/green]")
+        except ImportError:
+            console.print(
+                "[yellow]⚠️  pyperclip not available - cannot copy to clipboard automatically[/yellow]",
+            )
+            console.print(
+                "[dim]Copy the instructions above and provide them to your Cursor agent.[/dim]",
+            )
+        except Exception as e:
+            console.print(
+                f"[yellow]⚠️  Could not copy to clipboard: {e}[/yellow]",
+            )
+            console.print(
+                "[dim]Copy the instructions above and provide them to your Cursor agent.[/dim]",
+            )
+
+
 # =============================================================================
 # Top-Level Instructions Commands
 # =============================================================================
@@ -1212,11 +1486,17 @@ def view_all(
         help="Show only incomplete issues",
     ),
 ) -> None:
-    """View all documents across all categories or a specific category."""
+    """View all documents across all categories.
+
+    Passing a category argument is deprecated; use `cfs i <category> view` instead.
+    """
     from datetime import datetime
 
     from cfs import documents
     from cfs.documents import is_document_incomplete
+
+    if category:
+        _warn_deprecated(f"cfs i view {category}", f"cfs i {category} view")
 
     try:
         # Find CFS root
@@ -1341,26 +1621,12 @@ def view_all(
             console.print(table)
 
 
-@instructions_app.command("next")
-def next_document(
-    category: str = typer.Argument(..., help="Category name"),
-    force: bool = typer.Option(
-        False,
-        "--force",
-        "-y",
-        "--yes",
-        help="Skip confirmation and work on issue immediately",
-    ),
-) -> None:
+def _next_document_impl(category: str, force: bool) -> None:
     """Find and work on the next unresolved issue in a category.
 
-    This command finds the first unresolved document (not marked as DONE) in the
-    specified category, shows its title, and asks if you want to work on it.
-    If yes, it displays the full content and copies it to the clipboard.
-
-    Examples:
-        cfs instructions next bugs    # Work on the next bug
-        cfs instructions next features  # Work on the next feature
+    Finds the first unresolved document (not marked as DONE) in the specified
+    category, shows its title, and asks if you want to work on it. If yes, it
+    displays the full content and copies it to the clipboard.
     """
     from cfs.documents import (
         find_document_by_id,
@@ -1456,16 +1722,23 @@ def next_document(
         )
 
 
-@instructions_app.command("order")
-def order_documents_command(
+@instructions_app.command("next", hidden=True)
+def next_document(
     category: str = typer.Argument(..., help="Category name"),
     force: bool = typer.Option(
         False,
         "--force",
+        "-y",
         "--yes",
-        help="Skip confirmation and rename immediately",
+        help="Skip confirmation and work on issue immediately",
     ),
 ) -> None:
+    """[Deprecated] Use `cfs i <category> next` instead."""
+    _warn_deprecated(f"cfs i next {category}", f"cfs i {category} next")
+    _next_document_impl(category, force)
+
+
+def _order_documents_impl(category: str, force: bool) -> None:
     """Order documents in a category by renaming them to follow CFS naming convention."""
     from cfs import documents
 
@@ -1535,30 +1808,33 @@ def order_documents_command(
         raise typer.Abort()
 
 
-@instructions_app.command("move")
-def move_document_command(
-    source_category: str = typer.Argument(..., help="Source category name"),
-    doc_id: str = typer.Argument(..., help="Document ID (numeric or filename)"),
-    dest_category: str = typer.Argument(..., help="Destination category name"),
-    no_renumber: bool = typer.Option(
-        False,
-        "--no-renumber",
-        help="Skip renumbering documents in the source category after move",
-    ),
+@instructions_app.command("order", hidden=True)
+def order_documents_command(
+    category: str = typer.Argument(..., help="Category name"),
     force: bool = typer.Option(
         False,
         "--force",
         "-y",
         "--yes",
-        help="Skip confirmation prompt",
+        help="Skip confirmation and rename immediately",
     ),
+) -> None:
+    """[Deprecated] Use `cfs i <category> order` instead."""
+    _warn_deprecated(f"cfs i order {category}", f"cfs i {category} order")
+    _order_documents_impl(category, force)
+
+
+def _move_document_impl(
+    source_category: str,
+    doc_id: str,
+    dest_category: str,
+    no_renumber: bool,
+    force: bool,
 ) -> None:
     """Move a document from one category to another.
 
     The document receives a new sequential ID in the destination category.
     By default, documents in the source category are renumbered to fill the gap.
-
-    Example: cfs i move features 1 security
     """
     from cfs.documents import (
         find_document_by_id,
@@ -1645,6 +1921,32 @@ def move_document_command(
         raise typer.Abort()
 
 
+@instructions_app.command("move", hidden=True)
+def move_document_command(
+    source_category: str = typer.Argument(..., help="Source category name"),
+    doc_id: str = typer.Argument(..., help="Document ID (numeric or filename)"),
+    dest_category: str = typer.Argument(..., help="Destination category name"),
+    no_renumber: bool = typer.Option(
+        False,
+        "--no-renumber",
+        help="Skip renumbering documents in the source category after move",
+    ),
+    force: bool = typer.Option(
+        False,
+        "--force",
+        "-y",
+        "--yes",
+        help="Skip confirmation prompt",
+    ),
+) -> None:
+    """[Deprecated] Use `cfs i <category> move <id> <dest-category>` instead."""
+    _warn_deprecated(
+        f"cfs i move {source_category} {doc_id} {dest_category}",
+        f"cfs i {source_category} move {doc_id} {dest_category}",
+    )
+    _move_document_impl(source_category, doc_id, dest_category, no_renumber, force)
+
+
 # =============================================================================
 # Handoff Commands
 # =============================================================================
@@ -1657,7 +1959,7 @@ def handoff_callback(ctx: typer.Context) -> None:
         create_handoff()
 
 
-@handoff_app.command("create-handoff")
+@handoff_app.command("create")
 def create_handoff() -> None:
     """Generate instructions for creating a handoff document.
 
@@ -1773,6 +2075,13 @@ cfs instructions handoff pickup
         console.print(
             "[dim]Copy the instructions above and paste them into your Cursor agent.[/dim]",
         )
+
+
+@handoff_app.command("create-handoff", hidden=True)
+def create_handoff_deprecated() -> None:
+    """[Deprecated] Use `cfs i handoff create` instead."""
+    _warn_deprecated("cfs i handoff create-handoff", "cfs i handoff create")
+    create_handoff()
 
 
 @handoff_app.command("pickup")

--- a/src/cfs/core.py
+++ b/src/cfs/core.py
@@ -29,6 +29,19 @@ BUILTIN_CATEGORIES = {
 VALID_CATEGORIES = BUILTIN_CATEGORIES
 
 DEFAULT_HIDDEN_CATEGORIES = {"tmp", "security"}
+
+# Names that already exist as commands/sub-groups under `cfs instructions`,
+# so a custom category with one of these names would shadow or collide with them.
+RESERVED_CATEGORY_NAMES = {
+    "view",
+    "next",
+    "order",
+    "move",
+    "exec",
+    "handoff",
+    "category",
+}
+
 _CUSTOM_CATEGORY_NAME_RE = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
 _CATEGORY_CONFIG_FILE = ".cfs-categories.json"
 
@@ -152,6 +165,8 @@ def create_custom_category(cfs_root: Path, category: str, hidden: bool = False) 
         raise ValueError("Category name cannot be empty")
     if normalized in BUILTIN_CATEGORIES:
         raise ValueError(f"'{normalized}' is already a built-in category")
+    if normalized in RESERVED_CATEGORY_NAMES:
+        raise ValueError(f"'{normalized}' is a reserved command name and cannot be used")
     if not is_valid_custom_category_name(normalized):
         raise ValueError(
             "Category name must be lowercase letters/numbers with optional hyphens "

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1836,3 +1836,214 @@ class TestCreateCommandWithGithubAutoSync:
             assert "Closed document" in result.output
             assert "Closed GitHub issue #77" in result.output
             mock_close.assert_called_once_with(77)
+
+
+class TestConsistentCommandGrammar:
+    """Tests for the noun-first command grammar (issue #16).
+
+    Canonical forms are `cfs i <category> <verb> [id]`; the old verb-first
+    forms still work but emit a deprecation warning.
+    """
+
+    # --- New canonical forms ---
+
+    def test_category_next(self, runner, temp_cfs):
+        """`cfs i bugs next` finds the next unresolved document."""
+        tmp_path, cursor_dir = temp_cfs
+        (cursor_dir / "bugs" / "1-test-bug.md").write_text("# Test Bug\n\nContent here.")
+
+        with isolated_filesystem(tmp_path):
+            result = runner.invoke(
+                app,
+                ["instructions", "bugs", "next"],
+                input="n\n",  # Decline to work on it
+            )
+
+            assert "Next issue in bugs" in result.stdout
+            assert "Test Bug" in result.stdout
+            assert "deprecated" not in result.stdout
+
+    def test_category_order(self, runner, temp_cfs):
+        """`cfs i bugs order` reports when files already follow the convention."""
+        tmp_path, cursor_dir = temp_cfs
+        (cursor_dir / "bugs" / "1-test-bug.md").write_text("# Test Bug\n")
+
+        with isolated_filesystem(tmp_path):
+            result = runner.invoke(app, ["instructions", "bugs", "order"])
+
+            assert result.exit_code == 0
+            assert "already follow the naming convention" in result.stdout
+            assert "deprecated" not in result.stdout
+
+    def test_category_order_renames(self, runner, temp_cfs):
+        """`cfs i bugs order --force` renames non-conforming files."""
+        tmp_path, cursor_dir = temp_cfs
+        (cursor_dir / "bugs" / "5-test-bug.md").write_text("# Test Bug\n")
+
+        with isolated_filesystem(tmp_path):
+            result = runner.invoke(app, ["instructions", "bugs", "order", "--force"])
+
+            assert result.exit_code == 0
+            assert (cursor_dir / "bugs" / "1-test-bug.md").exists()
+
+    def test_category_move(self, runner, temp_cfs):
+        """`cfs i bugs move 1 features --force` moves a document."""
+        tmp_path, cursor_dir = temp_cfs
+        (cursor_dir / "bugs" / "1-test-bug.md").write_text("# Test Bug\n")
+
+        with isolated_filesystem(tmp_path):
+            result = runner.invoke(
+                app,
+                ["instructions", "bugs", "move", "1", "features", "--force"],
+            )
+
+            assert result.exit_code == 0
+            assert "Moved document" in result.stdout
+            assert (cursor_dir / "features" / "1-test-bug.md").exists()
+            assert not (cursor_dir / "bugs" / "1-test-bug.md").exists()
+            assert "deprecated" not in result.stdout
+
+    def test_category_exec(self, runner, temp_cfs):
+        """`cfs i bugs exec 1 --force` outputs the document content."""
+        tmp_path, cursor_dir = temp_cfs
+        (cursor_dir / "bugs" / "1-test-bug.md").write_text("# Test Bug\n\nUnique exec body.")
+
+        with isolated_filesystem(tmp_path):
+            result = runner.invoke(
+                app,
+                ["instructions", "bugs", "exec", "1", "--force"],
+            )
+
+            assert result.exit_code == 0
+            assert "Unique exec body." in result.stdout
+            assert "deprecated" not in result.stdout
+
+    def test_handoff_create(self, runner, temp_cfs):
+        """`cfs i handoff create` generates handoff instructions."""
+        tmp_path, cursor_dir = temp_cfs
+
+        with isolated_filesystem(tmp_path):
+            result = runner.invoke(app, ["instructions", "handoff", "create"])
+
+            assert result.exit_code == 0
+            assert "Handoff Instructions" in result.stdout
+            assert "deprecated" not in result.stdout
+
+    # --- Deprecated verb-first forms still work but warn ---
+
+    def test_deprecated_next_warns(self, runner, temp_cfs):
+        """`cfs i next bugs` still works and emits a deprecation warning."""
+        tmp_path, cursor_dir = temp_cfs
+        (cursor_dir / "bugs" / "1-test-bug.md").write_text("# Test Bug\n\nContent here.")
+
+        with isolated_filesystem(tmp_path):
+            result = runner.invoke(
+                app,
+                ["instructions", "next", "bugs"],
+                input="n\n",
+            )
+
+            assert "deprecated" in result.stdout
+            assert "Next issue in bugs" in result.stdout
+
+    def test_deprecated_order_warns(self, runner, temp_cfs):
+        """`cfs i order bugs` still works and emits a deprecation warning."""
+        tmp_path, cursor_dir = temp_cfs
+        (cursor_dir / "bugs" / "1-test-bug.md").write_text("# Test Bug\n")
+
+        with isolated_filesystem(tmp_path):
+            result = runner.invoke(app, ["instructions", "order", "bugs"])
+
+            assert result.exit_code == 0
+            assert "deprecated" in result.stdout
+            assert "already follow the naming convention" in result.stdout
+
+    def test_deprecated_move_warns(self, runner, temp_cfs):
+        """`cfs i move bugs 1 features` still works and emits a deprecation warning."""
+        tmp_path, cursor_dir = temp_cfs
+        (cursor_dir / "bugs" / "1-test-bug.md").write_text("# Test Bug\n")
+
+        with isolated_filesystem(tmp_path):
+            result = runner.invoke(
+                app,
+                ["instructions", "move", "bugs", "1", "features", "--force"],
+            )
+
+            assert result.exit_code == 0
+            assert "deprecated" in result.stdout
+            assert (cursor_dir / "features" / "1-test-bug.md").exists()
+
+    def test_deprecated_view_with_category_warns(self, runner, temp_cfs):
+        """`cfs i view bugs` still works and emits a deprecation warning."""
+        tmp_path, cursor_dir = temp_cfs
+        (cursor_dir / "bugs" / "1-test-bug.md").write_text("# Test Bug\n")
+
+        with isolated_filesystem(tmp_path):
+            result = runner.invoke(app, ["instructions", "view", "bugs"])
+
+            assert result.exit_code == 0
+            assert "deprecated" in result.stdout
+
+    def test_view_all_does_not_warn(self, runner, temp_cfs):
+        """Bare `cfs i view` (all categories) emits no deprecation warning."""
+        tmp_path, cursor_dir = temp_cfs
+        (cursor_dir / "bugs" / "1-test-bug.md").write_text("# Test Bug\n")
+
+        with isolated_filesystem(tmp_path):
+            result = runner.invoke(app, ["instructions", "view"])
+
+            assert result.exit_code == 0
+            assert "deprecated" not in result.stdout
+
+    def test_deprecated_handoff_create_warns(self, runner, temp_cfs):
+        """`cfs i handoff create-handoff` still works and emits a deprecation warning."""
+        tmp_path, cursor_dir = temp_cfs
+
+        with isolated_filesystem(tmp_path):
+            result = runner.invoke(app, ["instructions", "handoff", "create-handoff"])
+
+            assert result.exit_code == 0
+            assert "deprecated" in result.stdout
+            assert "Handoff Instructions" in result.stdout
+
+    def test_category_exec_rejects_multiple_ai_flags(self, runner, temp_cfs):
+        """`cfs i bugs exec` rejects more than one AI service flag."""
+        tmp_path, cursor_dir = temp_cfs
+        (cursor_dir / "bugs" / "1-test-bug.md").write_text("# Test Bug\n")
+
+        with isolated_filesystem(tmp_path):
+            result = runner.invoke(
+                app,
+                ["instructions", "bugs", "exec", "1", "--force", "--claude", "--gemini"],
+            )
+
+            assert result.exit_code != 0
+            assert "Only one AI service flag" in result.stdout
+
+    def test_category_move_same_category_rejected(self, runner, temp_cfs):
+        """`cfs i bugs move <id> bugs` is rejected."""
+        tmp_path, cursor_dir = temp_cfs
+        (cursor_dir / "bugs" / "1-test-bug.md").write_text("# Test Bug\n")
+
+        with isolated_filesystem(tmp_path):
+            result = runner.invoke(
+                app,
+                ["instructions", "bugs", "move", "1", "bugs", "--force"],
+            )
+
+            assert result.exit_code != 0
+            assert "same" in result.stdout
+
+    def test_custom_category_cannot_shadow_command_verbs(self, runner, temp_cfs):
+        """Custom categories cannot be named after reserved command verbs."""
+        tmp_path, cursor_dir = temp_cfs
+
+        with isolated_filesystem(tmp_path):
+            for reserved in ["next", "order", "move", "view", "exec", "handoff", "category"]:
+                result = runner.invoke(
+                    app,
+                    ["instructions", "category", "create", reserved],
+                )
+
+                assert result.exit_code != 0, f"'{reserved}' should be rejected"
+                assert "reserved" in result.stdout


### PR DESCRIPTION
Reorganize CFS command into a more logical order. Now there's a clear canonical grammar: cfs instr CATEGORY VERB plus anything else, such as id. Now CFS should be much more logical and intuitive to use, both for humans and for AI agents. 

- **refactor: adopt consistent noun-first command grammar (#16)**
- **chore: close CFS refactors/5 (command grammar) as done**
- **docs: add 0.11.0 changelog entry**
- **Bump version: 0.10.1 → 0.11.0**
- **fix: repair changelog headings mangled by bump2version; drop broken CHANGELOG rule**
