### PR TITLE
feature/29 top level category commands

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.11.0
+current_version = 0.12.0
 commit = True
 tag = True
 tag_name = v{new_version}
@@ -11,9 +11,3 @@ replace = version = "{new_version}"
 [bumpversion:file:src/cfs/__init__.py]
 search = __version__ = "{current_version}"
 replace = __version__ = "{new_version}"
-
-# Note: CHANGELOG.md is intentionally NOT managed by bump2version. A previous
-# [bumpversion:file:CHANGELOG.md] section here silently corrupted release
-# headings on every bump (it rewrote the literal old version string to
-# "## [Unreleased]"). Promote the Unreleased section to a dated release
-# heading manually before bumping.

--- a/.cursor/features/29-DONE-promote-categories-to-top-level-commands-cfs-category-verb-id.md
+++ b/.cursor/features/29-DONE-promote-categories-to-top-level-commands-cfs-category-verb-id.md
@@ -29,3 +29,5 @@ Design decisions (agreed in discussion):
 - README/AGENTS.md updated to present the top-level form as primary.
 
 ## Acceptance criteria
+
+<!-- DONE -->

--- a/.cursor/features/29-promote-categories-to-top-level-commands-cfs-category-verb-id.md
+++ b/.cursor/features/29-promote-categories-to-top-level-commands-cfs-category-verb-id.md
@@ -1,0 +1,31 @@
+---
+github_issue: 59
+---
+# Promote Categories To Top Level Commands Cfs Category Verb Id
+
+## Working directory
+
+`~/Desktop/cursor-instructions-cli`
+
+## Contents
+
+Building on the noun-first grammar from refactors/5 (#16), drop the required `instructions`/`instr`/`i` namespace so categories work directly at the top level: `cfs bugs complete 7`, `cfs features create`, `cfs bugs next`, etc.
+
+Design decisions (agreed in discussion):
+
+- **Keep `i`/`instr`/`instructions` as permanent aliases, not deprecated.** Muscle memory, CLAUDE.md files across repos, and CFS's own generated prompts (`cfs i <cat> complete <id> --force`) all use them. Both forms are canonical; docs prefer the short top-level form. Implementation is free: register the same Typer category apps on both the main app and the instructions app.
+- **Extend RESERVED_CATEGORY_NAMES to cover the top-level namespace**: `init`, `version`, `tree`, `view`, `exec`, `gh`, `rules` (plus the verbs already reserved). Custom categories must not shadow top-level commands, and future top-level commands should be chosen from / added to this list to avoid breaking custom categories.
+- **Promote `handoff` and `category` groups too**: `cfs handoff pickup`, `cfs category create <name>`, etc.
+- **Unify `cfs view` semantics while we're in there**: top-level `cfs view` currently means 'incomplete only' (alias of `cfs i view -i`) while `cfs i view` shows everything. Decide on one behavior and make both forms match.
+
+## Acceptance criteria
+
+- `cfs <category> <verb> [id] [flags]` works for all built-in and custom categories, with identical behavior to `cfs i <category> <verb>`.
+- `cfs i`/`cfs instr`/`cfs instructions` continue to work unchanged (no deprecation warnings).
+- Custom categories cannot be created with names that collide with top-level commands.
+- `cfs handoff ...` and `cfs category ...` work at the top level.
+- `cfs view` and `cfs i view` have unified, documented semantics.
+- Tests cover the new top-level forms, alias equivalence, and reserved-name rejection.
+- README/AGENTS.md updated to present the top-level form as primary.
+
+## Acceptance criteria

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,11 +49,13 @@ src/cfs/
 [Criteria for completion]
 ```
 
-The skeleton is generated in `cli.py:229` (`initial_content_lines`).
+The skeleton is generated in `cli_instructions.py` (`initial_content_lines`, inside the category `create` command).
 
 ### CLI Command Pattern
-Commands are organized under `cfs instructions {category}` (aliases: `instr`, `i`) and follow a
-uniform noun-first grammar: `cfs i <category> <verb> [id] [flags]`:
+Category commands work directly at the top level — `cfs <category> <verb> [id] [flags]` —
+and identically under the permanent `instructions`/`instr`/`i` aliases
+(e.g. `cfs bugs complete 7` == `cfs i bugs complete 7`). All follow a uniform
+noun-first grammar:
 - `create`, `edit`, `delete`, `view`, `complete`, `uncomplete`, `close`, `unclose`, `check`, `next`, `order`, `move`, `exec`
 
 Category commands are generated dynamically in `create_category_commands()` based on `VALID_CATEGORIES`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Top-level category commands (#59): the `instructions`/`instr`/`i` prefix is now optional — `cfs bugs complete 7`, `cfs features next`, `cfs handoff pickup`, and `cfs category create <name>` work directly at the top level. The prefixed forms remain permanent, equivalent aliases. Custom categories created at runtime are also available at the top level immediately.
+- Reserved top-level names: custom categories can no longer be named `init`, `version`, `tree`, `gh`, `instructions`, `instr`, or `i` (in addition to the command verbs already reserved).
+
+### Changed
+- Unified `view` semantics (#59): both `cfs view` and `cfs i view` now show incomplete documents by default; pass `--all`/`-a` to include completed/closed documents. (Previously `cfs i view` showed everything by default; the `-i` flag is still accepted but is now the default behavior.)
+
 ## [0.11.0] - 2026-06-11
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.0] - 2026-06-11
+
 ### Added
 - Top-level category commands (#59): the `instructions`/`instr`/`i` prefix is now optional — `cfs bugs complete 7`, `cfs features next`, `cfs handoff pickup`, and `cfs category create <name>` work directly at the top level. The prefixed forms remain permanent, equivalent aliases. Custom categories created at runtime are also available at the top level immediately.
 - Reserved top-level names: custom categories can no longer be named `init`, `version`, `tree`, `gh`, `instructions`, `instr`, or `i` (in addition to the command verbs already reserved).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Unified `view` semantics (#59): both `cfs view` and `cfs i view` now show incomplete documents by default; pass `--all`/`-a` to include completed/closed documents. (Previously `cfs i view` showed everything by default; the `-i` flag is still accepted but is now the default behavior.)
 
+### Security
+- Category discovery from disk now applies the same guards as category creation (reserved names and kebab-case validation). Previously a crafted directory in an untrusted repo (e.g. a cloned project shipping `.cursor/gh/`) would be registered as a top-level command group and could shadow the real command. Real command groups are also now registered after categories so they win any name collision (defense-in-depth).
+
 ## [0.11.0] - 2026-06-11
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -454,13 +454,13 @@ $ cfs instr planning-notes create --title "Q2 roadmap"
 
 ### Instructions Commands
 
-**Note:** You can use either `instructions` or the shorter `instr` alias for all commands below.
+**Note:** The `instructions` prefix is optional. `cfs bugs complete 7`, `cfs i bugs complete 7`, `cfs instr bugs complete 7`, and `cfs instructions bugs complete 7` are all equivalent; the prefixed forms are permanent aliases. Examples below use the `cfs instructions` form for clarity.
 
 - `cfs instructions <category> create [--title TITLE] [--edit] [--content TEXT]` - Create new document
 - `cfs instructions <category> edit <id> [--content TEXT]` - Edit existing document
 - `cfs instructions <category> delete <id> [--force]` - Delete document
 - `cfs instructions <category> view [id]` - View documents in category (or one document by ID)
-- `cfs instructions view` - View all documents across all categories
+- `cfs instructions view [--all/-a]` - View incomplete documents across all categories (`--all` includes completed); same as top-level `cfs view`
 - `cfs instructions <category> complete <id> [--force/-y]` - Mark document as done (requires confirmation)
 - `cfs instructions <category> order` - Order documents by naming convention
 - `cfs instructions <category> next` - Find and work on the next unresolved issue
@@ -473,12 +473,13 @@ $ cfs instr planning-notes create --title "Q2 roadmap"
 - `cfs instructions handoff create` - Generate instructions for creating a handoff document (or bare `cfs instructions handoff`)
 - `cfs instructions handoff pickup` - Pick up the first incomplete handoff document
 
-**Command grammar:** every category-scoped command follows the same order: `cfs instructions <category> <verb> [id] [flags]`. The old verb-first forms (`cfs i order <category>`, `cfs i next <category>`, `cfs i move <src> <id> <dest>`, `cfs i view <category>`, `cfs i handoff create-handoff`) still work but are deprecated, print a warning, and will be removed in a future version.
+**Command grammar:** every category-scoped command follows the same order: `cfs [instructions] <category> <verb> [id] [flags]` — the `instructions`/`instr`/`i` prefix is optional. The old verb-first forms (`cfs i order <category>`, `cfs i next <category>`, `cfs i move <src> <id> <dest>`, `cfs i view <category>`, `cfs i handoff create-handoff`) still work but are deprecated, print a warning, and will be removed in a future version.
 
-**Examples with short alias:**
-- `cfs instr view` - View all documents
-- `cfs instr bugs create --title "Fix bug"` - Create a bug document
-- `cfs instr features next` - Work on next feature
+**Examples with short forms:**
+- `cfs view` - View incomplete documents
+- `cfs bugs create --title "Fix bug"` - Create a bug document
+- `cfs features next` - Work on next feature
+- `cfs i bugs complete 3 --force` - The `i` alias works everywhere the bare form does
 
 ### Rules Commands
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "cursor-fs-cli"
-version = "0.11.0"
+version = "0.12.0"
 description = "CLI tool for managing Cursor File Structure (CFS) documents"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/src/cfs/__init__.py
+++ b/src/cfs/__init__.py
@@ -3,7 +3,7 @@
 A CLI for managing Cursor instruction documents within a structured file system.
 """
 
-__version__ = "0.11.0"
+__version__ = "0.12.0"
 
 # Export exceptions for easy access
 from cfs.exceptions import (

--- a/src/cfs/cli.py
+++ b/src/cfs/cli.py
@@ -14,7 +14,10 @@ from cfs.cli_helpers import (
     handle_cfs_error,
 )
 from cfs.cli_instructions import (
+    attach_categories_to,
+    category_admin_app,
     exec_document_impl,
+    handoff_app,
     instructions_app,
     view_all,
 )
@@ -35,6 +38,13 @@ app.add_typer(instructions_app, name="instr")  # Short alias for instructions
 app.add_typer(instructions_app, name="i")  # Shorter alias for instructions
 app.add_typer(rules_app, name="rules")
 app.add_typer(gh_app, name="gh")
+
+# Promote category command groups to the top level so `cfs bugs complete 7`
+# works alongside the equivalent `cfs i bugs complete 7`. The instructions
+# aliases above are permanent, not deprecated.
+attach_categories_to(app)
+app.add_typer(handoff_app, name="handoff")
+app.add_typer(category_admin_app, name="category")
 
 
 # Global options callback
@@ -125,10 +135,10 @@ This project uses CFS (Cursor File Structure) to manage instruction documents.{l
 ## Usage
 
 ```bash
-cfs instructions features create  # Create a feature request
-cfs instructions bugs create       # Create a bug report
-cfs instructions view              # View all documents
-cfs gh sync                        # Sync with GitHub issues
+cfs features create   # Create a feature request
+cfs bugs create       # Create a bug report
+cfs view              # View incomplete documents (--all for everything)
+cfs gh sync           # Sync with GitHub issues
 ```
 """
         init_file.write_text(init_content, encoding="utf-8")
@@ -225,14 +235,25 @@ def tree() -> None:
     console.print(tree_output)
 
 
-# Top-level view command (shortcut for `cfs i view -i`)
+# Top-level view command (same semantics as `cfs i view`)
 @app.command("view")
-def view_incomplete() -> None:
-    """View all incomplete documents across all categories.
-
-    This is a shortcut for 'cfs i view -i'.
-    """
-    view_all(category=None, incomplete_only=True)
+def view_incomplete(
+    all_docs: bool = typer.Option(
+        False,
+        "--all",
+        "-a",
+        help="Include completed/closed documents",
+    ),
+    incomplete_only: bool = typer.Option(
+        False,
+        "--incomplete-only",
+        "-i",
+        hidden=True,
+        help="Deprecated: incomplete documents are now shown by default",
+    ),
+) -> None:
+    """View incomplete documents across all categories (use --all to include completed)."""
+    view_all(category=None, all_docs=all_docs, incomplete_only=incomplete_only)
 
 
 @app.command("exec")

--- a/src/cfs/cli.py
+++ b/src/cfs/cli.py
@@ -32,17 +32,19 @@ app = typer.Typer(
     add_completion=False,
 )
 
+# Promote category command groups to the top level so `cfs bugs complete 7`
+# works alongside the equivalent `cfs i bugs complete 7`. Categories are
+# registered BEFORE the named groups below so that on any name collision the
+# real command groups win (Click resolves duplicate names last-wins). The
+# discovery path also filters reserved names — this ordering is defense-in-depth.
+attach_categories_to(app)
+
 # Register subcommand groups
 app.add_typer(instructions_app, name="instructions")
 app.add_typer(instructions_app, name="instr")  # Short alias for instructions
 app.add_typer(instructions_app, name="i")  # Shorter alias for instructions
 app.add_typer(rules_app, name="rules")
 app.add_typer(gh_app, name="gh")
-
-# Promote category command groups to the top level so `cfs bugs complete 7`
-# works alongside the equivalent `cfs i bugs complete 7`. The instructions
-# aliases above are permanent, not deprecated.
-attach_categories_to(app)
 app.add_typer(handoff_app, name="handoff")
 app.add_typer(category_admin_app, name="category")
 

--- a/src/cfs/cli_instructions.py
+++ b/src/cfs/cli_instructions.py
@@ -67,6 +67,20 @@ def _warn_deprecated(old_form: str, new_form: str) -> None:
 
 _REGISTERED_CATEGORY_COMMANDS: set[str] = set()
 
+# Every Typer app that should expose the per-category command groups. The
+# instructions app is always a target; the main `cfs` app registers itself via
+# attach_categories_to() so categories also work at the top level
+# (`cfs bugs complete 7` as well as `cfs i bugs complete 7`).
+_CATEGORY_APP_TARGETS: list[typer.Typer] = [instructions_app]
+_CATEGORY_APPS: dict[str, typer.Typer] = {}
+
+
+def attach_categories_to(target_app: typer.Typer) -> None:
+    """Expose all category command groups (current and future) on another Typer app."""
+    _CATEGORY_APP_TARGETS.append(target_app)
+    for name, category_app in _CATEGORY_APPS.items():
+        target_app.add_typer(category_app, name=name)
+
 
 @category_admin_app.command("create")
 def create_category_command(
@@ -194,9 +208,12 @@ def create_category_commands(categories: Optional[set[str]] = None) -> None:
         if category == "rules" or category in _REGISTERED_CATEGORY_COMMANDS:
             continue
 
-        # Create a Typer app for this category
+        # Create a Typer app for this category and register it on every target
+        # app (the instructions group plus the top-level `cfs` app).
         category_app = typer.Typer(name=category, help=f"Manage {category} documents")
-        instructions_app.add_typer(category_app, name=category)
+        _CATEGORY_APPS[category] = category_app
+        for target_app in _CATEGORY_APP_TARGETS:
+            target_app.add_typer(category_app, name=category)
         _REGISTERED_CATEGORY_COMMANDS.add(category)
 
         # Create all commands for this category with proper closure capture
@@ -1479,14 +1496,21 @@ def view_all(
         None,
         help="Optional category name to filter by",
     ),
+    all_docs: bool = typer.Option(
+        False,
+        "--all",
+        "-a",
+        help="Include completed/closed documents",
+    ),
     incomplete_only: bool = typer.Option(
         False,
         "--incomplete-only",
         "-i",
-        help="Show only incomplete issues",
+        hidden=True,
+        help="Deprecated: incomplete documents are now shown by default",
     ),
 ) -> None:
-    """View all documents across all categories.
+    """View incomplete documents across all categories (use --all to include completed).
 
     Passing a category argument is deprecated; use `cfs i <category> view` instead.
     """
@@ -1497,6 +1521,10 @@ def view_all(
 
     if category:
         _warn_deprecated(f"cfs i view {category}", f"cfs i {category} view")
+
+    # Incomplete-only is the default; --all includes completed/closed documents.
+    # The hidden -i flag is accepted for backward compatibility but matches the default.
+    incomplete_only = not all_docs
 
     try:
         # Find CFS root
@@ -1516,7 +1544,7 @@ def view_all(
     # List documents
     docs_dict = documents.list_documents(cfs_root, category)
 
-    # Filter to incomplete only if flag is set
+    # Filter to incomplete only unless --all is set
     if incomplete_only:
         for cat in docs_dict:
             docs_dict[cat] = [doc for doc in docs_dict[cat] if is_document_incomplete(doc)]

--- a/src/cfs/core.py
+++ b/src/cfs/core.py
@@ -30,16 +30,27 @@ VALID_CATEGORIES = BUILTIN_CATEGORIES
 
 DEFAULT_HIDDEN_CATEGORIES = {"tmp", "security"}
 
-# Names that already exist as commands/sub-groups under `cfs instructions`,
-# so a custom category with one of these names would shadow or collide with them.
+# Names that already exist as commands/sub-groups at the top level or under
+# `cfs instructions`, so a custom category with one of these names would shadow
+# or collide with them. Future top-level commands must be added here.
 RESERVED_CATEGORY_NAMES = {
+    # command verbs available per category
     "view",
     "next",
     "order",
     "move",
     "exec",
+    # sub-groups
     "handoff",
     "category",
+    "instructions",
+    "instr",
+    "i",
+    "gh",
+    # top-level commands
+    "init",
+    "version",
+    "tree",
 }
 
 _CUSTOM_CATEGORY_NAME_RE = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")

--- a/src/cfs/core.py
+++ b/src/cfs/core.py
@@ -118,7 +118,14 @@ def _write_category_config(cfs_root: Path, config: dict) -> None:
 
 
 def get_custom_categories(cfs_root: Path) -> Set[str]:
-    """Get all custom categories present as directories under .cursor."""
+    """Get all custom categories present as directories under .cursor.
+
+    Discovery applies the same guards as creation: directories whose names are
+    reserved command names or are not valid kebab-case are ignored. Without
+    this, a crafted directory in an untrusted repo (e.g. a cloned project
+    shipping `.cursor/gh/`) would be registered as a top-level command group
+    and shadow the real command.
+    """
     if not cfs_root.exists() or not cfs_root.is_dir():
         return set()
 
@@ -129,6 +136,10 @@ def get_custom_categories(cfs_root: Path) -> Set[str]:
         if entry.name.startswith("."):
             continue
         if entry.name in BUILTIN_CATEGORIES:
+            continue
+        if entry.name in RESERVED_CATEGORY_NAMES:
+            continue
+        if not is_valid_custom_category_name(entry.name):
             continue
         categories.add(entry.name)
     return categories

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2047,3 +2047,148 @@ class TestConsistentCommandGrammar:
 
                 assert result.exit_code != 0, f"'{reserved}' should be rejected"
                 assert "reserved" in result.stdout
+
+
+class TestTopLevelCategoryCommands:
+    """Tests for top-level category grammar (issue #59): `cfs <category> <verb> [id]`.
+
+    The `instructions`/`instr`/`i` forms remain permanent, equivalent aliases.
+    """
+
+    def test_top_level_create_and_view(self, runner, temp_cfs):
+        """`cfs bugs create` and `cfs bugs view` work without the `i` prefix."""
+        tmp_path, cursor_dir = temp_cfs
+
+        with isolated_filesystem(tmp_path):
+            result = runner.invoke(
+                app,
+                ["bugs", "create", "--title", "Top level bug", "--content", "Body."],
+            )
+
+            assert result.exit_code == 0
+            assert (cursor_dir / "bugs" / "1-top-level-bug.md").exists()
+
+            result = runner.invoke(app, ["bugs", "view"])
+            assert result.exit_code == 0
+            assert "top-level-bug" in result.stdout
+
+    def test_top_level_equivalent_to_i_form(self, runner, temp_cfs):
+        """Top-level and `i`-prefixed forms run the same command."""
+        tmp_path, cursor_dir = temp_cfs
+        (cursor_dir / "bugs" / "1-test-bug.md").write_text("# Test Bug\n\nContent.")
+
+        with isolated_filesystem(tmp_path):
+            top = runner.invoke(app, ["bugs", "next"], input="n\n")
+            aliased = runner.invoke(app, ["i", "bugs", "next"], input="n\n")
+
+            assert "Next issue in bugs" in top.stdout
+            assert "Next issue in bugs" in aliased.stdout
+            assert "deprecated" not in top.stdout
+            assert "deprecated" not in aliased.stdout
+
+    def test_top_level_complete(self, runner, temp_cfs):
+        """`cfs bugs complete <id>` works at the top level."""
+        tmp_path, cursor_dir = temp_cfs
+        (cursor_dir / "bugs" / "1-test-bug.md").write_text("# Test Bug\n")
+
+        with isolated_filesystem(tmp_path):
+            result = runner.invoke(app, ["bugs", "complete", "1", "--force"])
+
+            assert result.exit_code == 0
+            assert (cursor_dir / "bugs" / "1-DONE-test-bug.md").exists()
+
+    def test_top_level_handoff_and_category_groups(self, runner, temp_cfs):
+        """`cfs handoff` and `cfs category list` work at the top level."""
+        tmp_path, cursor_dir = temp_cfs
+
+        with isolated_filesystem(tmp_path):
+            result = runner.invoke(app, ["handoff", "create"])
+            assert result.exit_code == 0
+            assert "Handoff Instructions" in result.stdout
+
+            result = runner.invoke(app, ["category", "list"])
+            assert result.exit_code == 0
+            assert "bugs" in result.stdout
+
+    def test_runtime_custom_category_works_at_top_level(self, runner, temp_cfs):
+        """A custom category created at runtime is immediately usable at the top level."""
+        tmp_path, cursor_dir = temp_cfs
+
+        with isolated_filesystem(tmp_path):
+            result = runner.invoke(app, ["category", "create", "toplevel-notes"])
+            assert result.exit_code == 0
+
+            result = runner.invoke(
+                app,
+                ["toplevel-notes", "create", "--title", "A note", "--content", "Body."],
+            )
+            assert result.exit_code == 0
+            assert (cursor_dir / "toplevel-notes" / "1-a-note.md").exists()
+
+            # The same runtime-created category must also work via the `i` alias
+            # (proves the multi-target backfill registers on both apps).
+            result = runner.invoke(app, ["i", "toplevel-notes", "view"])
+            assert result.exit_code == 0
+            assert "a-note" in result.stdout
+
+    def test_top_level_names_are_reserved(self, runner, temp_cfs):
+        """Custom categories cannot shadow top-level commands or groups."""
+        tmp_path, cursor_dir = temp_cfs
+
+        with isolated_filesystem(tmp_path):
+            for reserved in ["init", "version", "tree", "gh", "instructions", "instr", "i"]:
+                result = runner.invoke(app, ["category", "create", reserved])
+
+                assert result.exit_code != 0, f"'{reserved}' should be rejected"
+                assert "reserved" in result.stdout
+
+
+class TestUnifiedViewSemantics:
+    """`cfs view` and `cfs i view` both default to incomplete-only; --all shows everything."""
+
+    def _make_docs(self, cursor_dir):
+        (cursor_dir / "bugs" / "1-DONE-finished-bug.md").write_text("# Finished\n")
+        (cursor_dir / "bugs" / "2-open-bug.md").write_text("# Open\n")
+
+    def test_top_level_view_defaults_to_incomplete(self, runner, temp_cfs):
+        tmp_path, cursor_dir = temp_cfs
+        self._make_docs(cursor_dir)
+
+        with isolated_filesystem(tmp_path):
+            result = runner.invoke(app, ["view"])
+
+            assert result.exit_code == 0
+            assert "open-bug" in result.stdout
+            assert "finished-bug" not in result.stdout
+
+    def test_top_level_view_all_includes_completed(self, runner, temp_cfs):
+        tmp_path, cursor_dir = temp_cfs
+        self._make_docs(cursor_dir)
+
+        with isolated_filesystem(tmp_path):
+            result = runner.invoke(app, ["view", "--all"])
+
+            assert result.exit_code == 0
+            assert "open-bug" in result.stdout
+            assert "finished-bug" in result.stdout
+
+    def test_i_view_matches_top_level_default(self, runner, temp_cfs):
+        tmp_path, cursor_dir = temp_cfs
+        self._make_docs(cursor_dir)
+
+        with isolated_filesystem(tmp_path):
+            result = runner.invoke(app, ["i", "view"])
+
+            assert result.exit_code == 0
+            assert "open-bug" in result.stdout
+            assert "finished-bug" not in result.stdout
+
+    def test_i_view_all_includes_completed(self, runner, temp_cfs):
+        tmp_path, cursor_dir = temp_cfs
+        self._make_docs(cursor_dir)
+
+        with isolated_filesystem(tmp_path):
+            result = runner.invoke(app, ["i", "view", "--all"])
+
+            assert result.exit_code == 0
+            assert "finished-bug" in result.stdout

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -149,3 +149,52 @@ class TestCustomCategoryConfig:
         assert category_path.exists()
         assert "work" in get_all_categories(cursor_dir)
         assert "work" in get_hidden_categories(cursor_dir)
+
+
+class TestCategoryDiscoveryGuards:
+    """Discovery of categories from disk applies the same guards as creation.
+
+    Without these guards, a crafted directory in an untrusted repo (e.g. a
+    cloned project shipping `.cursor/gh/`) would be registered as a top-level
+    command group and shadow the real command.
+    """
+
+    def _make_cursor(self, tmp_path):
+        cursor_dir = tmp_path / ".cursor"
+        cursor_dir.mkdir()
+        return cursor_dir
+
+    def test_reserved_name_dirs_are_not_discovered(self, tmp_path):
+        from cfs.core import RESERVED_CATEGORY_NAMES, get_custom_categories
+
+        cursor_dir = self._make_cursor(tmp_path)
+        for name in ["gh", "init", "version", "tree", "i", "handoff"]:
+            (cursor_dir / name).mkdir()
+        (cursor_dir / "legit-notes").mkdir()
+
+        discovered = get_custom_categories(cursor_dir)
+
+        assert discovered == {"legit-notes"}
+        assert not discovered & RESERVED_CATEGORY_NAMES
+
+    def test_invalid_name_dirs_are_not_discovered(self, tmp_path):
+        from cfs.core import get_custom_categories
+
+        cursor_dir = self._make_cursor(tmp_path)
+        for name in ["UPPER", "has_underscore", "trailing-", "with space"]:
+            (cursor_dir / name).mkdir()
+        (cursor_dir / "valid-name").mkdir()
+
+        assert get_custom_categories(cursor_dir) == {"valid-name"}
+
+    def test_command_registration_excludes_reserved_dirs(self, tmp_path):
+        from cfs.core import categories_for_command_registration
+
+        cursor_dir = self._make_cursor(tmp_path)
+        (cursor_dir / "gh").mkdir()
+        (cursor_dir / "legit-notes").mkdir()
+
+        registered = categories_for_command_registration(start_path=tmp_path)
+
+        assert "gh" not in registered
+        assert "legit-notes" in registered


### PR DESCRIPTION
- **docs: add CFS features/29 for top-level category commands**
- **feat: promote category commands to the top level (#59)**
- **chore: close CFS features/29 (top-level category commands) as done**
- **security: guard category discovery against reserved-name shadowing**
- **docs: add 0.12.0 changelog entry**
- **Bump version: 0.11.0 → 0.12.0**
