### PR TITLE
fix/bugs 16 sync conflict loop

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.12.0
+current_version = 0.12.1
 commit = True
 tag = True
 tag_name = v{new_version}

--- a/.cursor/bugs/16-DONE-gh-sync-conflict-loop-section-parsers-not-code-fence-aware.md
+++ b/.cursor/bugs/16-DONE-gh-sync-conflict-loop-section-parsers-not-code-fence-aware.md
@@ -26,3 +26,5 @@ Trigger case: GitHub #54 (bugs/15) is a bug report about document templates, so 
 - Regression tests cover fenced headings in extract_document_sections, build_github_issue_body, and _split_github_issue_body, plus an end-to-end convergence test.
 
 ## Acceptance criteria
+
+<!-- DONE -->

--- a/.cursor/bugs/16-gh-sync-conflict-loop-section-parsers-not-code-fence-aware.md
+++ b/.cursor/bugs/16-gh-sync-conflict-loop-section-parsers-not-code-fence-aware.md
@@ -1,0 +1,28 @@
+---
+github_issue: 61
+---
+# Gh Sync Conflict Loop Section Parsers Not Code Fence Aware
+
+## Working directory
+
+`~/Desktop/cursor-instructions-cli`
+
+## Contents
+
+Resolving a content conflict via `cfs gh sync` does not converge for documents whose content contains heading-like lines inside fenced code blocks: the same conflict reappears on every subsequent sync.
+
+Root cause: three parsers treat ANY line starting with `## ` as a section header, even inside ``` code fences:
+
+- `extract_document_sections()` (documents.py)
+- `build_github_issue_body()` (uses the above)
+- `_split_github_issue_body()` (sync.py)
+
+Trigger case: GitHub #54 (bugs/15) is a bug report about document templates, so its body contains fenced blocks with literal `## Working directory` / `## Contents` / `## Acceptance Criteria` lines. After resolving with 'use GitHub', the next sync re-extracts the CFS doc's contents but resets at the embedded `## Contents` inside the fence, producing a different canonical body than GitHub's — so the conflict reappears forever. Resolving with 'use CFS' would instead overwrite the GitHub issue with a truncated body (data loss).
+
+## Acceptance criteria
+
+- Section extraction and issue-body splitting ignore heading-like lines inside fenced code blocks (``` and ~~~).
+- A resolved conflict stays resolved: after applying either resolution, the next sync detects no conflict for the same content (round-trip convergence), including for the real bugs/15 / #54 content shape.
+- Regression tests cover fenced headings in extract_document_sections, build_github_issue_body, and _split_github_issue_body, plus an end-to-end convergence test.
+
+## Acceptance criteria

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- `cfs gh sync` conflict loop (bugs/16, #61): markdown section parsing is now code-fence-aware, and unknown `## ` subsections are kept as content of their parent section instead of being dropped. Previously, documents whose content embedded heading-like lines (e.g. a template example inside a code block, or GitHub-style `## Summary` subsections) were extracted differently than they were written, so a resolved content conflict reappeared on every subsequent sync — and resolving with "use CFS" could truncate the GitHub issue body.
+
 ## [0.12.0] - 2026-06-11
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.1] - 2026-06-11
+
 ### Fixed
 - `cfs gh sync` conflict loop (bugs/16, #61): markdown section parsing is now code-fence-aware, and unknown `## ` subsections are kept as content of their parent section instead of being dropped. Previously, documents whose content embedded heading-like lines (e.g. a template example inside a code block, or GitHub-style `## Summary` subsections) were extracted differently than they were written, so a resolved content conflict reappeared on every subsequent sync — and resolving with "use CFS" could truncate the GitHub issue body.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "cursor-fs-cli"
-version = "0.12.0"
+version = "0.12.1"
 description = "CLI tool for managing Cursor File Structure (CFS) documents"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/src/cfs/__init__.py
+++ b/src/cfs/__init__.py
@@ -3,7 +3,7 @@
 A CLI for managing Cursor instruction documents within a structured file system.
 """
 
-__version__ = "0.12.0"
+__version__ = "0.12.1"
 
 # Export exceptions for easy access
 from cfs.exceptions import (

--- a/src/cfs/documents.py
+++ b/src/cfs/documents.py
@@ -1294,8 +1294,52 @@ def remove_github_issue_link(content: str) -> str:
     return remove_frontmatter_key(content, "github_issue")
 
 
+_CODE_FENCE_RE = re.compile(r"^(`{3,}|~{3,})")
+
+
+class CodeFenceTracker:
+    """Track fenced code block state while scanning markdown line by line.
+
+    Follows the CommonMark rules that matter here: a fence opens with three or
+    more backticks or tildes (an info string may follow), and closes only with
+    a fence of the same character at least as long, with nothing else on the
+    line. Lines inside a fence — including the fence delimiters themselves —
+    must not be parsed as headings; otherwise documents whose content embeds
+    template examples (e.g. a literal `## Contents` inside a code block) are
+    extracted differently than they were written, which broke `gh sync`
+    round-trips.
+    """
+
+    def __init__(self) -> None:
+        self._open_char: Optional[str] = None
+        self._open_len = 0
+
+    def process(self, line: str) -> bool:
+        """Advance state with this line; return True if it belongs to a fenced block."""
+        stripped = line.strip()
+        match = _CODE_FENCE_RE.match(stripped)
+        if self._open_char is None:
+            if match:
+                self._open_char = match.group(1)[0]
+                self._open_len = len(match.group(1))
+                return True
+            return False
+        if (
+            match
+            and match.group(1)[0] == self._open_char
+            and len(match.group(1)) >= self._open_len
+            and stripped[len(match.group(1)) :].strip() == ""
+        ):
+            self._open_char = None
+            self._open_len = 0
+        return True
+
+
 def extract_document_sections(content: str) -> Dict[str, str]:
     """Extract sections from a CFS document.
+
+    Heading detection is code-fence-aware: lines inside ``` or ~~~ blocks are
+    treated as section content, never as headers.
 
     Args:
         content: Full document content (with or without frontmatter).
@@ -1316,8 +1360,15 @@ def extract_document_sections(content: str) -> Dict[str, str]:
     lines = body.split("\n")
     current_section = None
     section_content: List[str] = []
+    fence = CodeFenceTracker()
 
     for line in lines:
+        # Lines inside fenced code blocks are content, never headers
+        if fence.process(line):
+            if current_section:
+                section_content.append(line)
+            continue
+
         # Check for title (h1)
         if line.startswith("# ") and not sections["title"]:
             sections["title"] = line[2:].strip()
@@ -1325,21 +1376,26 @@ def extract_document_sections(content: str) -> Dict[str, str]:
 
         # Check for section headers (h2)
         if line.startswith("## "):
-            # Save previous section content
-            if current_section and section_content:
-                sections[current_section] = "\n".join(section_content).strip()
-                section_content = []
-
             header = line[3:].strip().lower()
+            known_section = None
             if "working" in header and "directory" in header:
-                current_section = "working_directory"
+                known_section = "working_directory"
             elif header == "contents":
-                current_section = "contents"
+                known_section = "contents"
             elif "acceptance" in header and "criteria" in header:
-                current_section = "acceptance_criteria"
-            else:
-                current_section = None
-            continue
+                known_section = "acceptance_criteria"
+
+            if known_section is not None:
+                # Save previous section content and switch sections
+                if current_section and section_content:
+                    sections[current_section] = "\n".join(section_content).strip()
+                    section_content = []
+                current_section = known_section
+                continue
+            # Unknown h2 headers (e.g. "## Summary" in a GitHub-sourced body)
+            # are subsections of the current section, not section breaks —
+            # treating them as breaks dropped their content and broke gh sync
+            # round-trips. Fall through to accumulate the line as content.
 
         # Accumulate content for current section
         if current_section:

--- a/src/cfs/sync.py
+++ b/src/cfs/sync.py
@@ -19,6 +19,7 @@ from cfs.core import (
     get_hidden_categories,
 )
 from cfs.documents import (
+    CodeFenceTracker,
     build_github_issue_body,
     check_duplicates,
     complete_document,
@@ -219,9 +220,12 @@ def _split_github_issue_body(body: str, normalize: bool = False) -> Tuple[str, s
     contents_lines: List[str] = []
     acceptance_lines: List[str] = []
     in_acceptance = False
+    fence = CodeFenceTracker()
 
     for line in lines:
-        if _ACCEPTANCE_HEADER_RE.match(line.strip()):
+        # Heading detection is code-fence-aware: a literal "## Acceptance
+        # Criteria" inside a code block is content, not a section break.
+        if not fence.process(line) and _ACCEPTANCE_HEADER_RE.match(line.strip()):
             in_acceptance = True
             continue
         if in_acceptance:

--- a/tests/test_frontmatter.py
+++ b/tests/test_frontmatter.py
@@ -395,3 +395,126 @@ Here's some **bold** and `code`.
         assert "**bold**" in body
         assert "`code`" in body
         assert "- List item 1" in body
+
+
+class TestCodeFenceAwareExtraction:
+    """Section extraction must not treat heading-like lines inside code fences
+    as section breaks, and unknown h2 subsections belong to their parent
+    section (bugs/16: gh sync conflict loop)."""
+
+    def test_fenced_headers_are_content_not_section_breaks(self):
+        content = """# Title
+
+## Contents
+
+Example of the template:
+
+```markdown
+# Repro
+
+## Working directory
+
+`~/some/path`
+
+## Contents
+
+MY BODY LINE ONE
+
+## Acceptance Criteria
+```
+
+After the fence.
+
+## Acceptance criteria
+
+- Real criterion
+"""
+        sections = extract_document_sections(content)
+
+        assert "MY BODY LINE ONE" in sections["contents"]
+        assert "## Working directory" in sections["contents"]
+        assert "After the fence." in sections["contents"]
+        # The fenced `~/some/path` must not leak into working_directory
+        assert sections["working_directory"] == ""
+        assert sections["acceptance_criteria"] == "- Real criterion"
+
+    def test_tilde_fences_are_respected(self):
+        content = """# Title
+
+## Contents
+
+~~~
+## Acceptance criteria
+~~~
+
+## Acceptance criteria
+
+- Real
+"""
+        sections = extract_document_sections(content)
+
+        assert "## Acceptance criteria" in sections["contents"]
+        assert sections["acceptance_criteria"] == "- Real"
+
+    def test_unknown_h2_headers_are_kept_as_section_content(self):
+        content = """# Title
+
+## Contents
+
+## Summary
+
+GitHub-style body with its own subsections.
+
+## Environment
+
+- macOS
+
+## Acceptance criteria
+
+- Done
+"""
+        sections = extract_document_sections(content)
+
+        assert "## Summary" in sections["contents"]
+        assert "## Environment" in sections["contents"]
+        assert "- macOS" in sections["contents"]
+        assert sections["acceptance_criteria"] == "- Done"
+
+    def test_round_trip_extraction_is_stable(self):
+        """Extracting, embedding into a fresh skeleton, and re-extracting must
+        produce the same contents — this is what keeps gh sync conflicts from
+        reappearing after resolution."""
+        github_style_body = """## Summary
+
+Report with a template example:
+
+```markdown
+## Contents
+
+MY BODY LINE ONE
+```
+
+Closing remarks."""
+
+        doc = "\n".join(
+            [
+                "# Some Issue",
+                "",
+                "## Working directory",
+                "",
+                "`~/repo`",
+                "",
+                "## Contents",
+                "",
+                github_style_body,
+                "",
+                "## Acceptance criteria",
+                "",
+            ]
+        )
+
+        first = extract_document_sections(doc)["contents"]
+        redoc = f"# Some Issue\n\n## Contents\n\n{first}\n"
+        second = extract_document_sections(redoc)["contents"]
+
+        assert first == second == github_style_body

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -820,3 +820,90 @@ class TestBuildSyncPlanDuplicates:
 
         create_cfs_actions = [a for a in plan.get_actions() if a.action == SyncAction.CREATE_CFS]
         assert len(create_cfs_actions) == 0
+
+
+class TestFenceAwareSyncComparison:
+    """Conflict comparison and body splitting must be code-fence-aware so a
+    resolved conflict stays resolved (bugs/16)."""
+
+    GITHUB_BODY = """## Summary
+
+A report whose repro embeds the document template:
+
+```markdown
+# Repro
+
+## Contents
+
+MY BODY LINE ONE
+
+## Acceptance Criteria
+```
+
+Closing remarks.
+
+## Acceptance criteria
+
+- Real criterion
+"""
+
+    def test_split_ignores_fenced_acceptance_header(self):
+        from cfs.sync import _split_github_issue_body
+
+        contents, acceptance = _split_github_issue_body(self.GITHUB_BODY, normalize=False)
+
+        assert "MY BODY LINE ONE" in contents
+        assert "## Acceptance Criteria" in contents  # the fenced one stays in contents
+        assert acceptance.strip() == "- Real criterion"
+
+    def test_remote_resolution_converges(self):
+        """Rebuilding the CFS doc from the GitHub body (the 'use GitHub'
+        resolution) must produce equal canonical bodies on the next compare."""
+        from cfs.sync import _get_comparable_bodies, _split_github_issue_body
+
+        contents, acceptance = _split_github_issue_body(self.GITHUB_BODY, normalize=False)
+        resolved_doc_lines = [
+            "# Some Issue",
+            "",
+            "## Working directory",
+            "",
+            "`~/repo`",
+            "",
+            "## Contents",
+            "",
+            contents,
+            "",
+            "## Acceptance criteria",
+            "",
+            acceptance,
+        ]
+        resolved_doc = "\n".join(resolved_doc_lines)
+
+        cfs_body, github_body = _get_comparable_bodies(resolved_doc, self.GITHUB_BODY)
+
+        assert cfs_body == github_body
+
+    def test_local_resolution_converges(self):
+        """Pushing the CFS doc to GitHub (the 'use CFS' resolution) must also
+        produce equal canonical bodies on the next compare."""
+        from cfs.documents import build_github_issue_body
+        from cfs.sync import _get_comparable_bodies
+
+        cfs_doc = "\n".join(
+            [
+                "# Some Issue",
+                "",
+                "## Contents",
+                "",
+                self.GITHUB_BODY.split("\n## Acceptance criteria")[0],
+                "",
+                "## Acceptance criteria",
+                "",
+                "- Real criterion",
+            ]
+        )
+        pushed_body = build_github_issue_body(cfs_doc)
+
+        cfs_body, github_body = _get_comparable_bodies(cfs_doc, pushed_body)
+
+        assert cfs_body == github_body


### PR DESCRIPTION
Fixes a bug where some CFS sync was never working properly because of code fences. 

- **docs: add CFS bugs/16 for gh sync conflict loop**
- **fix: make section parsing code-fence-aware to stop gh sync conflict loop (#61)**
- **chore: close CFS bugs/16 (sync conflict loop) as done**
- **docs: add 0.12.1 changelog entry**
- **Bump version: 0.12.0 → 0.12.1**
